### PR TITLE
Simplify the logic for the dust file path

### DIFF
--- a/src/superphot_plus/sfd/__init__.py
+++ b/src/superphot_plus/sfd/__init__.py
@@ -4,21 +4,8 @@ This package contains the dust maps for superphot_plus.
 import os
 from pathlib import Path
 
-from astropy.utils.data import get_pkg_data_filename
-
 import superphot_plus
 
-__all__ = ["rootdir", "get_dust_filepath"]
+__all__ = ["dust_filepath"]
 
-rootdir = Path(os.path.dirname(superphot_plus.__file__)) / "sfd"
-
-
-def get_dust_filepath(**kwargs):
-    """Return the path to the directory with the dust files.
-
-    Returns
-    -------
-    filepath : `str`
-        The path of the directory.
-    """
-    return get_pkg_data_filename(filename, package="superphot_plus.sfd", **kwargs)
+dust_filepath = os.path.dirname(superphot_plus.__file__)

--- a/src/superphot_plus/utils.py
+++ b/src/superphot_plus/utils.py
@@ -6,7 +6,7 @@ from astropy.coordinates import SkyCoord
 from dustmaps.config import config
 from dustmaps.sfd import SFDQuery
 
-from superphot_plus.sfd import get_dust_filepath
+from superphot_plus.sfd import dust_filepath
 
 
 def get_band_extinctions(ra, dec):
@@ -14,7 +14,7 @@ def get_band_extinctions(ra, dec):
     Get green and red band extinctions in magnitudes for
     a single supernova LC based on RA and DEC.
     """
-    config["data_dir"] = get_dust_filepath()
+    config["data_dir"] = dust_filepath
     sfd = SFDQuery()
 
     # First look up the amount of mw dust at this location

--- a/tests/superphot_plus/test_utils.py
+++ b/tests/superphot_plus/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from superphot_plus.utils import calc_accuracy
+from superphot_plus.utils import calc_accuracy, get_band_extinctions
 
 
 def test_calc_accuracy() -> None:
@@ -26,3 +26,11 @@ def test_calc_accuracy() -> None:
     # Check a array size mismatch.
     with pytest.raises(ValueError):
         _ = calc_accuracy(np.array([1, 2, 3]), truth)
+
+
+def test_get_band_extinctions() -> None:
+    """This is currently a change detection test where we are just confirming
+    the function runs correctly returns the same value as it used to.
+    """
+    ext_list = get_band_extinctions(0.0, 10.0)
+    assert np.all(ext_list == pytest.approx([0.3133, 0.2202], 0.01))


### PR DESCRIPTION
Logic for the dust file path was unnecessarily complicated.

Adds a change detection test to confirm that the dust files are being loaded.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
