### PR TITLE
Add a unit test for f1_score

### DIFF
--- a/src/superphot_plus/utils.py
+++ b/src/superphot_plus/utils.py
@@ -112,8 +112,7 @@ def f1_score(pred_classes, true_classes, class_average=False):
     if class_average:
         return f1_sum / len(samples_per_class.keys())
 
-    total_samples = np.sum(samples_per_class.values())
-    return f1_sum / total_samples
+    return f1_sum / len(true_classes)
 
 
 def convert_mags_to_flux(m, merr, zp):

--- a/tests/superphot_plus/test_utils.py
+++ b/tests/superphot_plus/test_utils.py
@@ -1,7 +1,11 @@
 import numpy as np
 import pytest
 
-from superphot_plus.utils import calc_accuracy, get_band_extinctions
+from superphot_plus.utils import (
+    calc_accuracy,
+    f1_score,
+    get_band_extinctions,
+)
 
 
 def test_calc_accuracy() -> None:
@@ -26,6 +30,32 @@ def test_calc_accuracy() -> None:
     # Check a array size mismatch.
     with pytest.raises(ValueError):
         _ = calc_accuracy(np.array([1, 2, 3]), truth)
+
+
+def test_f1_score() -> None:
+    # One true positive of each class and one mislabel.
+    s = f1_score(np.array([1, 1, 0]), np.array([0, 1, 0]), True)
+    assert pytest.approx(s) == 2.0 / 3.0
+    s = f1_score(np.array([1, 1, 0]), np.array([0, 1, 0]), False)
+    assert pytest.approx(s) == 2.0 / 3.0
+
+    # F1s for each class will be: [4/5, 8/9, 1, 1, 1]
+    s = f1_score(
+        np.array([0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4]),
+        np.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 4, 4]),
+        True,
+    )
+    assert pytest.approx(s) == (4.0 / 5.0 + 6.0 / 7.0 + 1.0 + 1.0 + 1.0) / 5.0
+
+    s = f1_score(
+        np.array([0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4]),
+        np.array([0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 4, 4]),
+        False,
+    )
+    assert (
+        pytest.approx(s)
+        == (2.0 * (4.0 / 5.0) + 4.0 * (6.0 / 7.0) + 2.0 + 2.0 + 2.0) / 12.0
+    )
 
 
 def test_get_band_extinctions() -> None:


### PR DESCRIPTION
Adds a unit test for the f1 score.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
