### PR TITLE
Vectorize create_prior

### DIFF
--- a/src/superphot_plus/constants.py
+++ b/src/superphot_plus/constants.py
@@ -19,6 +19,29 @@ PRIOR_TAU_RISE_g = [0.5, 2.0, 0.9663, 0.0128]
 PRIOR_TAU_FALL_g = [0.1, 3.0, 0.5488, 0.0553]
 PRIOR_EXTRA_SIGMA_g = [0.2, 2.0, 0.8606, 0.0388]
 
+# The priors in columnar format with columns for
+# clip_a, clip_b, mean, std
+ALL_PRIORS = np.transpose(
+    np.array(
+        [
+            PRIOR_A,
+            PRIOR_BETA,
+            PRIOR_GAMMA,
+            PRIOR_T0,
+            PRIOR_TAU_RISE,
+            PRIOR_TAU_FALL,
+            PRIOR_EXTRA_SIGMA,
+            PRIOR_A_g,
+            PRIOR_BETA_g,
+            PRIOR_GAMMA_g,
+            PRIOR_T0_g,
+            PRIOR_TAU_RISE_g,
+            PRIOR_TAU_FALL_g,
+            PRIOR_EXTRA_SIGMA_g,
+        ]
+    )
+)
+
 # Nested sampling parameters
 MAX_ITER = 5000
 DLOGZ = 0.5

--- a/src/superphot_plus/ztf_transient_fit.py
+++ b/src/superphot_plus/ztf_transient_fit.py
@@ -177,13 +177,13 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None):
         cube[6] = 10 ** (tg_vals[6])  # lognormal for extrasigma, UPDATED
 
         # green band
-        cube[7] = tg_vals[7]
-        cube[8] = tg_vals[8]
-        cube[9] = tg_vals[9]
-        cube[10] = tg_vals[10]
-        cube[11] = tg_vals[11]
-        cube[12] = tg_vals[12]
-        cube[13] = tg_vals[13]
+        cube[7] = tg_vals[7]  # A UPDATED
+        cube[8] = tg_vals[8]  # beta UPDATED
+        cube[9] = tg_vals[9]  # gamma, GAUSSIAN not Lorentzian
+        cube[10] = tg_vals[10]  # t0 UPDATED
+        cube[11] = tg_vals[11]  # taurise UPDATED, Gaussian
+        cube[12] = tg_vals[12]  # taufall UPDATED
+        cube[13] = tg_vals[13]  # extra sigma UPDATED, Gaussian
 
         return cube
 

--- a/src/superphot_plus/ztf_transient_fit.py
+++ b/src/superphot_plus/ztf_transient_fit.py
@@ -170,11 +170,11 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None):
 
         cube[0] = max_flux * 10 ** tg_vals[0]  # log-uniform for A from 1.0x to 16x of max flux
         cube[1] = tg_vals[1]  # beta UPDATED, looks more Lorentzian so widened by 1.5x
-        cube[2] = 10 ** (tg_vals[2])  # very broad Gaussian temporary solution for gamma
+        cube[2] = 10 ** tg_vals[2]  # very broad Gaussian temporary solution for gamma
         cube[3] = tg_vals[3]
-        cube[4] = 10 ** (tg_vals[4])  # taurise, UPDATED
-        cube[5] = 10 ** (tg_vals[5])  # tau fall UPDATED
-        cube[6] = 10 ** (tg_vals[6])  # lognormal for extrasigma, UPDATED
+        cube[4] = 10 ** tg_vals[4]  # taurise, UPDATED
+        cube[5] = 10 ** tg_vals[5]  # tau fall UPDATED
+        cube[6] = 10 ** tg_vals[6]  # lognormal for extrasigma, UPDATED
 
         # g band
         cube[7] = tg_vals[7]  # A UPDATED

--- a/src/superphot_plus/ztf_transient_fit.py
+++ b/src/superphot_plus/ztf_transient_fit.py
@@ -168,7 +168,7 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None):
         # Compute the truncated Gaussian distribution for all values at once.
         tg_vals = truncnorm.ppf(cube, tg_a, tg_b, loc=prior_mean, scale=prior_std)
 
-        cube[0] = max_flux * 10 ** (tg_vals[0])  # log-uniform for A from 1.0x to 16x of max flux
+        cube[0] = max_flux * 10 ** tg_vals[0]  # log-uniform for A from 1.0x to 16x of max flux
         cube[1] = tg_vals[1]  # beta UPDATED, looks more Lorentzian so widened by 1.5x
         cube[2] = 10 ** (tg_vals[2])  # very broad Gaussian temporary solution for gamma
         cube[3] = tg_vals[3]

--- a/src/superphot_plus/ztf_transient_fit.py
+++ b/src/superphot_plus/ztf_transient_fit.py
@@ -176,7 +176,7 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None):
         cube[5] = 10 ** (tg_vals[5])  # tau fall UPDATED
         cube[6] = 10 ** (tg_vals[6])  # lognormal for extrasigma, UPDATED
 
-        # green band
+        # g band
         cube[7] = tg_vals[7]  # A UPDATED
         cube[8] = tg_vals[8]  # beta UPDATED
         cube[9] = tg_vals[9]  # gamma, GAUSSIAN not Lorentzian

--- a/src/superphot_plus/ztf_transient_fit.py
+++ b/src/superphot_plus/ztf_transient_fit.py
@@ -137,7 +137,7 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None):
     # current lightcurve.
     prior_clip_a = np.copy(ALL_PRIORS[0])
     prior_clip_a[3] = np.amin(tdata) - 50.0
-    
+
     prior_clip_b = np.copy(ALL_PRIORS[1])
     prior_clip_b[3] = np.amax(tdata) + 50.0
 
@@ -168,9 +168,8 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None):
         # Compute the truncated Gaussian distribution for all values at once.
         tg_vals = truncnorm.ppf(cube, tg_a, tg_b, loc=prior_mean, scale=prior_std)
 
-        # log-uniform for A from 1.0x to 16x of max flux
-        cube[0] = max_flux * 10 ** (tg_vals[0])
-        cube[1] = tg_vals[1]
+        cube[0] = max_flux * 10 ** (tg_vals[0])  # log-uniform for A from 1.0x to 16x of max flux
+        cube[1] = tg_vals[1]  # beta UPDATED, looks more Lorentzian so widened by 1.5x
         cube[2] = 10 ** (tg_vals[2])  # very broad Gaussian temporary solution for gamma
         cube[3] = tg_vals[3]
         cube[4] = 10 ** (tg_vals[4])  # taurise, UPDATED


### PR DESCRIPTION
Vectorize the computations in `create_prior` in the dynesty sampling mode. This speeds up the computation time by >10x (503.3 seconds to 33.4 seconds on the profiling test).

It does this by:
1) using numpy vectorized operations to compute the a and b values for the truncated Gaussian.
2) remove 14 individual the calls to `trunc_gauss`, and
3) call `truncnorm.ppf` once using vectors.

This was difficult to test because `create_prior` is an inner function and not callable from the unit tests. I tested this by initially implementing both methods in `create_prior` using a copy of the input `cube` and comparing the result values within `create_prior`.  This testing code (performing the computation twice) was removed prior to sending the PR.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation