### PR TITLE
Utility class to hold per-band curve priors.

### DIFF
--- a/src/superphot_plus/constants.py
+++ b/src/superphot_plus/constants.py
@@ -2,46 +2,6 @@
 
 import numpy as np
 
-# Nested sampling priors
-PRIOR_A = [-0.2, 1.2, 0.0, 0.5]
-PRIOR_BETA = [0.0, 0.02, 0.0052, 1.5 * 0.000336]
-PRIOR_GAMMA = [-2.0, 2.5, 1.1391, 1.5 * 0.1719]
-PRIOR_T0 = [-100.0, 200.0, 0.0, 50.0]
-PRIOR_TAU_RISE = [-1.0, 3.0, 0.5990, 1.5 * 0.2073]
-PRIOR_TAU_FALL = [0.5, 4.0, 1.4296, 1.5 * 0.1003]
-PRIOR_EXTRA_SIGMA = [-5.0, -0.5, -1.5364, 0.2691]
-
-PRIOR_A_g = [0.0, 5.0, 1.0607, 1.5 * 0.1544]
-PRIOR_BETA_g = [1.0, 1.07, 1.0424, 0.0026]
-PRIOR_GAMMA_g = [0.8, 1.2, 1.0075, 0.0139]
-PRIOR_T0_g = [1.0 - 0.0006, 1.0006, 0.9999 + 8.9289e-5, 1.5 * 4.5055e-05]
-PRIOR_TAU_RISE_g = [0.5, 2.0, 0.9663, 0.0128]
-PRIOR_TAU_FALL_g = [0.1, 3.0, 0.5488, 0.0553]
-PRIOR_EXTRA_SIGMA_g = [0.2, 2.0, 0.8606, 0.0388]
-
-# The priors in columnar format with columns for
-# clip_a, clip_b, mean, std
-ALL_PRIORS = np.transpose(
-    np.array(
-        [
-            PRIOR_A,
-            PRIOR_BETA,
-            PRIOR_GAMMA,
-            PRIOR_T0,
-            PRIOR_TAU_RISE,
-            PRIOR_TAU_FALL,
-            PRIOR_EXTRA_SIGMA,
-            PRIOR_A_g,
-            PRIOR_BETA_g,
-            PRIOR_GAMMA_g,
-            PRIOR_T0_g,
-            PRIOR_TAU_RISE_g,
-            PRIOR_TAU_FALL_g,
-            PRIOR_EXTRA_SIGMA_g,
-        ]
-    )
-)
-
 # Nested sampling parameters
 MAX_ITER = 5000
 DLOGZ = 0.5

--- a/src/superphot_plus/data_generation/make_fake_spp_data.py
+++ b/src/superphot_plus/data_generation/make_fake_spp_data.py
@@ -1,12 +1,51 @@
 import numpy as np
 from scipy.stats import truncnorm
 
-from ..utils import flux_model
-from ..constants import *
-from ..ztf_transient_fit import trunc_gauss, params_valid
+from superphot_plus.utils import flux_model
+from superphot_plus.ztf_transient_fit import params_valid
 
 DEFAULT_MAX_FLUX = 1.0
+# Nested sampling priors
+PRIOR_A = [-0.2, 1.2, 0.0, 0.5]
+PRIOR_BETA = [0.0, 0.02, 0.0052, 1.5 * 0.000336]
+PRIOR_GAMMA = [-2.0, 2.5, 1.1391, 1.5 * 0.1719]
+PRIOR_T0 = [-100.0, 200.0, 0.0, 50.0]
+PRIOR_TAU_RISE = [-1.0, 3.0, 0.5990, 1.5 * 0.2073]
+PRIOR_TAU_FALL = [0.5, 4.0, 1.4296, 1.5 * 0.1003]
+PRIOR_EXTRA_SIGMA = [-5.0, -0.5, -1.5364, 0.2691]
 
+PRIOR_A_g = [0.0, 5.0, 1.0607, 1.5 * 0.1544]
+PRIOR_BETA_g = [1.0, 1.07, 1.0424, 0.0026]
+PRIOR_GAMMA_g = [0.8, 1.2, 1.0075, 0.0139]
+PRIOR_T0_g = [1.0 - 0.0006, 1.0006, 0.9999 + 8.9289e-5, 1.5 * 4.5055e-05]
+PRIOR_TAU_RISE_g = [0.5, 2.0, 0.9663, 0.0128]
+PRIOR_TAU_FALL_g = [0.1, 3.0, 0.5488, 0.0553]
+PRIOR_EXTRA_SIGMA_g = [0.2, 2.0, 0.8606, 0.0388]
+
+def trunc_gauss(quantile, clip_a, clip_b, mean, std):
+    """Truncated Gaussian distribution.
+
+    Parameters
+    ----------
+    quantile : float
+        The quantile at which to evaluate the ppf. Should be a value
+        between 0 and 1.
+    clip_a : float
+        Lower clip value.
+    clip_b : float
+        Upper clip value.
+    mean : float
+        Mean of the distribution.
+    std : float
+        Standard deviation of the distribution.
+
+    Returns
+    -------
+    scipy.stats.truncnorm.ppf
+        Percent point function of the truncated Gaussian.
+    """
+    a, b = (clip_a - mean) / std, (clip_b - mean) / std
+    return truncnorm.ppf(quantile, a, b, loc=mean, scale=std)
 
 def create_prior(cube):
     """Creates prior for dynesty, where each side of the "cube"

--- a/src/superphot_plus/fit_numpyro.py
+++ b/src/superphot_plus/fit_numpyro.py
@@ -6,6 +6,7 @@ equally weighted posteriors (sets of fit parameters).
 import os
 
 import jax.numpy as jnp
+import numpy as np
 import numpyro
 import numpyro.distributions as dist
 from jax import random
@@ -13,19 +14,18 @@ from jax.config import config
 from numpyro.contrib.nested_sampling import NestedSampler
 from numpyro.distributions import constraints
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
+from numpyro.infer.initialization import init_to_sample, init_to_uniform
 
+from superphot_plus.constants import PAD_SIZE
+from superphot_plus.file_paths import FITS_DIR
+from superphot_plus.file_utils import get_posterior_filename
+from superphot_plus.lightcurve import Lightcurve
 from superphot_plus.plotting import (
     plot_posterior_hist,
     plot_sampling_lc_fit_numpyro,
     plot_sampling_trace_numpyro,
 )
-from numpyro.infer.initialization import init_to_sample, init_to_uniform
-
-from superphot_plus.lightcurve import Lightcurve
-from superphot_plus.file_utils import get_posterior_filename
-
-from .constants import *  # pylint: disable=wildcard-import
-from .file_paths import FIT_PLOTS_FOLDER, FITS_DIR
+from superphot_plus.priors.fitting_priors import MultibandPriors, PriorFields
 
 config.update("jax_enable_x64", True)
 numpyro.enable_x64()
@@ -51,6 +51,22 @@ def trunc_norm(low, high, loc, scale):
         A truncated normal distribution.
     """
     return dist.TruncatedNormal(loc=loc, scale=scale, low=low, high=high)
+
+
+def trunc_norm_fields(fields: PriorFields):
+    """Provides keyword parameters to numpyro's TruncatedNormal, using the fields in PriorFields.
+
+    Parameters
+    ----------
+    fields : PriorFields
+        The (low, high, mean, standard deviation) fields of the truncated normal distribution.
+
+    Returns
+    -------
+    numpyro.distributions.TruncatedDistribution
+        A truncated normal distribution.
+    """
+    return dist.TruncatedNormal(loc=fields.mean, scale=fields.std, low=fields.clip_a, high=fields.clip_b)
 
 
 def run_mcmc(lc, sampler="NUTS", t0_lim=None, plot=False):
@@ -109,30 +125,25 @@ def run_mcmc(lc, sampler="NUTS", t0_lim=None, plot=False):
         inc_band_ix : array-like, optional
             Index values for the band. Defaults to None.
         """
-        A = max_flux * 10 ** numpyro.sample("logA", trunc_norm(*PRIOR_A))
-        beta = numpyro.sample("beta", trunc_norm(*PRIOR_BETA))
-        gamma = 10 ** numpyro.sample("log_gamma", trunc_norm(*PRIOR_GAMMA))
-        t0 = numpyro.sample("t0", trunc_norm(*PRIOR_T0))
-        tau_rise = 10 ** numpyro.sample("log_tau_rise", trunc_norm(*PRIOR_TAU_RISE))
-        tau_fall = 10 ** numpyro.sample("log_tau_fall", trunc_norm(*PRIOR_TAU_FALL))
-        extra_sigma = 10 ** numpyro.sample("log_extra_sigma", trunc_norm(*PRIOR_EXTRA_SIGMA))
+        all_priors = MultibandPriors.load_ztf_priors()
+        r_priors = all_priors.bands["r"]
+        A = max_flux * 10 ** numpyro.sample("logA", trunc_norm_fields(r_priors.amp))
+        beta = numpyro.sample("beta", trunc_norm_fields(r_priors.beta))
+        gamma = 10 ** numpyro.sample("log_gamma", trunc_norm_fields(r_priors.gamma))
+        t0 = numpyro.sample("t0", trunc_norm_fields(r_priors.t_0))
+        tau_rise = 10 ** numpyro.sample("log_tau_rise", trunc_norm_fields(r_priors.tau_rise))
+        tau_fall = 10 ** numpyro.sample("log_tau_fall", trunc_norm_fields(r_priors.tau_fall))
+        extra_sigma = 10 ** numpyro.sample("log_extra_sigma", trunc_norm_fields(r_priors.extra_sigma))
 
-        A_g = numpyro.sample("A_g", trunc_norm(*PRIOR_A_g))
-        beta_g = numpyro.sample("beta_g", trunc_norm(*PRIOR_BETA_g))
-        gamma_g = numpyro.sample("gamma_g", trunc_norm(*PRIOR_GAMMA_g))
-        t0_g = numpyro.sample("t0_g", trunc_norm(*PRIOR_T0_g))
-        tau_rise_g = numpyro.sample("tau_rise_g", trunc_norm(*PRIOR_TAU_RISE_g))
-        tau_fall_g = numpyro.sample("tau_fall_g", trunc_norm(*PRIOR_TAU_FALL_g))
-        extra_sigma_g = numpyro.sample("extra_sigma_g", trunc_norm(*PRIOR_EXTRA_SIGMA_g))
-        """
-        A_g = numpyro.param("A_g", 1.)
-        beta_g = numpyro.param("beta_g", 1.)
-        gamma_g = numpyro.param("gamma_g", 1.)
-        t0_g = numpyro.param("t0_g", 1.)
-        tau_rise_g = numpyro.param("tau_rise_g", 1.)
-        tau_fall_g = numpyro.param("tau_fall_g", 1.)
-        extra_sigma_g = numpyro.param("extra_sigma_g", 1.)
-        """
+        g_priors = all_priors.bands["g"]
+        A_g = numpyro.sample("A_g", trunc_norm_fields(g_priors.amp))
+        beta_g = numpyro.sample("beta_g", trunc_norm_fields(g_priors.beta))
+        gamma_g = numpyro.sample("gamma_g", trunc_norm_fields(g_priors.gamma))
+        t0_g = numpyro.sample("t0_g", trunc_norm_fields(g_priors.t_0))
+        tau_rise_g = numpyro.sample("tau_rise_g", trunc_norm_fields(g_priors.tau_rise))
+        tau_fall_g = numpyro.sample("tau_fall_g", trunc_norm_fields(g_priors.tau_fall))
+        extra_sigma_g = numpyro.sample("extra_sigma_g", trunc_norm_fields(g_priors.extra_sigma))
+
         A_b = A * A_g  # pylint: disable=unused-variable
         beta_b = beta * beta_g
         gamma_b = gamma * gamma_g
@@ -193,119 +204,35 @@ def run_mcmc(lc, sampler="NUTS", t0_lim=None, plot=False):
         inc_band_ix : array-like, optional
             Index values for the band. Defaults to None.
         """
-        logA_mu = numpyro.param(
-            "logA_mu",
-            PRIOR_A[2],
-            constraint=constraints.interval(PRIOR_A[0], PRIOR_A[1]),
-        )
-        logA_sigma = numpyro.param("logA_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("logA", dist.Normal(logA_mu, logA_sigma))
 
-        beta_mu = numpyro.param(
-            "beta_mu",
-            PRIOR_BETA[2],
-            constraint=constraints.interval(PRIOR_BETA[0], PRIOR_BETA[1]),
-        )
-        beta_sigma = numpyro.param("beta_sigma", 1e-5, constraint=constraints.positive)
-        numpyro.sample("beta", dist.Normal(beta_mu, beta_sigma))
+        def numpyro_sample(prefix: str, fields: PriorFields, param_constraint: float):
+            param_mu = numpyro.param(
+                f"{prefix}_mu",
+                fields.mean,
+                constraint=constraints.interval(fields.clip_a, fields.clip_b),
+            )
+            param_sigma = numpyro.param(f"{prefix}_sigma", param_constraint, constraint=constraints.positive)
+            numpyro.sample(prefix, dist.Normal(param_mu, param_sigma))
 
-        log_gamma_mu = numpyro.param(
-            "log_gamma_mu",
-            PRIOR_GAMMA[2],
-            constraint=constraints.interval(PRIOR_GAMMA[0], PRIOR_GAMMA[1]),
-        )
-        log_gamma_sigma = numpyro.param("log_gamma_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("log_gamma", dist.Normal(log_gamma_mu, log_gamma_sigma))
-
-        t0_mu = numpyro.param(
-            "t0_mu",
-            PRIOR_T0[2],
-            constraint=constraints.interval(PRIOR_T0[0], PRIOR_T0[1]),
-        )
-        t0_sigma = numpyro.param("t0_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("t0", dist.Normal(t0_mu, t0_sigma))
-
-        log_tau_rise_mu = numpyro.param(
-            "log_tau_rise_mu",
-            PRIOR_TAU_RISE[2],
-            constraint=constraints.interval(PRIOR_TAU_RISE[0], PRIOR_TAU_RISE[1]),
-        )
-        log_tau_rise_sigma = numpyro.param("log_tau_rise_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("log_tau_rise", dist.Normal(log_tau_rise_mu, log_tau_rise_sigma))
-
-        log_tau_fall_mu = numpyro.param(
-            "log_tau_fall_mu",
-            PRIOR_TAU_FALL[2],
-            constraint=constraints.interval(PRIOR_TAU_FALL[0], PRIOR_TAU_FALL[1]),
-        )
-        log_tau_fall_sigma = numpyro.param("log_tau_fall_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("log_tau_fall", dist.Normal(log_tau_fall_mu, log_tau_fall_sigma))
-
-        log_extra_sigma_mu = numpyro.param(
-            "log_extra_sigma_mu",
-            PRIOR_EXTRA_SIGMA[2],
-            constraint=constraints.interval(PRIOR_EXTRA_SIGMA[0], PRIOR_EXTRA_SIGMA[1]),
-        )
-        log_extra_sigma_sigma = numpyro.param("log_extra_sigma_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("log_extra_sigma", dist.Normal(log_extra_sigma_mu, log_extra_sigma_sigma))
+        all_priors = MultibandPriors.load_ztf_priors()
+        r_priors = all_priors.bands["r"]
+        numpyro_sample("logA", r_priors.amp, 1e-3)
+        numpyro_sample("beta", r_priors.beta, 1e-5)
+        numpyro_sample("log_gamma", r_priors.gamma, 1e-3)
+        numpyro_sample("t0", r_priors.t_0, 1e-3)
+        numpyro_sample("log_tau_rise", r_priors.tau_rise, 1e-3)
+        numpyro_sample("log_tau_fall", r_priors.tau_fall, 1e-3)
+        numpyro_sample("log_extra_sigma", r_priors.extra_sigma, 1e-3)
 
         # aux bands
-
-        Ag_mu = numpyro.param(
-            "A_g_mu",
-            PRIOR_A_g[2],
-            constraint=constraints.interval(PRIOR_A_g[0], PRIOR_A_g[1]),
-        )
-        Ag_sigma = numpyro.param("A_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("A_g", dist.Normal(Ag_mu, Ag_sigma))
-
-        beta_g_mu = numpyro.param(
-            "beta_g_mu",
-            PRIOR_BETA_g[2],
-            constraint=constraints.interval(PRIOR_BETA_g[0], PRIOR_BETA_g[1]),
-        )
-        beta_g_sigma = numpyro.param("beta_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("beta_g", dist.Normal(beta_g_mu, beta_g_sigma))
-
-        gamma_g_mu = numpyro.param(
-            "gamma_g_mu",
-            PRIOR_GAMMA_g[2],
-            constraint=constraints.interval(PRIOR_GAMMA_g[0], PRIOR_GAMMA_g[1]),
-        )
-        gamma_g_sigma = numpyro.param("gamma_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("gamma_g", dist.Normal(gamma_g_mu, gamma_g_sigma))
-
-        t0_g_mu = numpyro.param(
-            "t0_g_mu",
-            PRIOR_T0_g[2],
-            constraint=constraints.interval(PRIOR_T0_g[0], PRIOR_T0_g[1]),
-        )
-        t0_g_sigma = numpyro.param("t0_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("t0_g", dist.Normal(t0_g_mu, t0_g_sigma))
-
-        tau_rise_g_mu = numpyro.param(
-            "tau_rise_g_mu",
-            PRIOR_TAU_RISE_g[2],
-            constraint=constraints.interval(PRIOR_TAU_RISE_g[0], PRIOR_TAU_RISE_g[1]),
-        )
-        tau_rise_g_sigma = numpyro.param("tau_rise_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("tau_rise_g", dist.Normal(tau_rise_g_mu, tau_rise_g_sigma))
-
-        tau_fall_g_mu = numpyro.param(
-            "tau_fall_g_mu",
-            PRIOR_TAU_FALL_g[2],
-            constraint=constraints.interval(PRIOR_TAU_FALL_g[0], PRIOR_TAU_FALL_g[1]),
-        )
-        tau_fall_g_sigma = numpyro.param("tau_fall_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("tau_fall_g", dist.Normal(tau_fall_g_mu, tau_fall_g_sigma))
-
-        extra_sigma_g_mu = numpyro.param(
-            "extra_sigma_g_mu",
-            PRIOR_EXTRA_SIGMA_g[2],
-            constraint=constraints.interval(PRIOR_EXTRA_SIGMA_g[0], PRIOR_EXTRA_SIGMA_g[1]),
-        )
-        extra_sigma_g_sigma = numpyro.param("extra_sigma_g_sigma", 1e-3, constraint=constraints.positive)
-        numpyro.sample("extra_sigma_g", dist.Normal(extra_sigma_g_mu, extra_sigma_g_sigma))
+        g_priors = all_priors.bands["g"]
+        numpyro_sample("A_g", g_priors.amp, 1e-3)
+        numpyro_sample("beta_g", g_priors.beta, 1e-3)
+        numpyro_sample("gamma_g", g_priors.gamma, 1e-3)
+        numpyro_sample("t0_g", g_priors.t_0, 1e-3)
+        numpyro_sample("tau_rise_g", g_priors.tau_rise, 1e-3)
+        numpyro_sample("tau_fall_g", g_priors.tau_fall, 1e-3)
+        numpyro_sample("extra_sigma_g", g_priors.extra_sigma, 1e-3)
 
     if sampler == "NUTS":
         num_samples = 300
@@ -487,21 +414,25 @@ def run_mcmc_batch(lcs, t0_lim=None, plot=False):
             Index values for the band. Defaults to None.
         """
         with numpyro.plate("components", N) as sn_index:  # pylint: disable=unused-variable
-            A = max_flux * 10 ** numpyro.sample("logA", trunc_norm(*PRIOR_A))
-            beta = numpyro.sample("beta", trunc_norm(*PRIOR_BETA))
-            gamma = 10 ** numpyro.sample("log_gamma", trunc_norm(*PRIOR_GAMMA))
-            t0 = numpyro.sample("t0", trunc_norm(-100.0, 200.0, 0.0, 20.0))
-            tau_rise = 10 ** numpyro.sample("log_tau_rise", trunc_norm(*PRIOR_TAU_RISE))
-            tau_fall = 10 ** numpyro.sample("log_tau_fall", trunc_norm(*PRIOR_TAU_FALL))
-            extra_sigma = 10 ** numpyro.sample("log_extra_sigma", trunc_norm(*PRIOR_EXTRA_SIGMA))
 
-            A_g = numpyro.sample("A_g", trunc_norm(*PRIOR_A_g))
-            beta_g = numpyro.sample("beta_g", trunc_norm(*PRIOR_BETA_g))
-            gamma_g = numpyro.sample("gamma_g", trunc_norm(*PRIOR_GAMMA_g))
-            t0_g = numpyro.sample("t0_g", trunc_norm(*PRIOR_T0_g))
-            tau_rise_g = numpyro.sample("tau_rise_g", trunc_norm(*PRIOR_TAU_RISE_g))
-            tau_fall_g = numpyro.sample("tau_fall_g", trunc_norm(*PRIOR_TAU_FALL_g))
-            extra_sigma_g = numpyro.sample("extra_sigma_g", trunc_norm(*PRIOR_EXTRA_SIGMA_g))
+            all_priors = MultibandPriors.load_ztf_priors()
+            r_priors = all_priors.bands["r"]
+            A = max_flux * 10 ** numpyro.sample("logA", trunc_norm_fields(r_priors.amp))
+            beta = numpyro.sample("beta", trunc_norm_fields(r_priors.beta))
+            gamma = 10 ** numpyro.sample("log_gamma", trunc_norm_fields(r_priors.gamma))
+            t0 = numpyro.sample("t0", trunc_norm(-100.0, 200.0, 0.0, 20.0))
+            tau_rise = 10 ** numpyro.sample("log_tau_rise", trunc_norm_fields(r_priors.tau_rise))
+            tau_fall = 10 ** numpyro.sample("log_tau_fall", trunc_norm_fields(r_priors.tau_fall))
+            extra_sigma = 10 ** numpyro.sample("log_extra_sigma", trunc_norm_fields(r_priors.extra_sigma))
+
+            g_priors = all_priors.bands["g"]
+            A_g = numpyro.sample("A_g", trunc_norm_fields(g_priors.amp))
+            beta_g = numpyro.sample("beta_g", trunc_norm_fields(g_priors.beta))
+            gamma_g = numpyro.sample("gamma_g", trunc_norm_fields(g_priors.gamma))
+            t0_g = numpyro.sample("t0_g", trunc_norm_fields(g_priors.t_0))
+            tau_rise_g = numpyro.sample("tau_rise_g", trunc_norm_fields(g_priors.tau_rise))
+            tau_fall_g = numpyro.sample("tau_fall_g", trunc_norm_fields(g_priors.tau_fall))
+            extra_sigma_g = numpyro.sample("extra_sigma_g", trunc_norm_fields(g_priors.extra_sigma))
 
         A_b = A * A_g  # pylint: disable=unused-variable
         beta_b = beta * beta_g

--- a/src/superphot_plus/priors/fitting_priors.py
+++ b/src/superphot_plus/priors/fitting_priors.py
@@ -1,0 +1,112 @@
+import dataclasses
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+import numpy as np
+import yaml
+from typing_extensions import Self
+
+import superphot_plus
+
+
+@dataclass
+class PriorFields:
+    """Holder for per-parameter field characterization"""
+
+    clip_a: float = 0
+    clip_b: float = 0
+    mean: float = 0
+    std: float = 0
+
+    def to_numpy(self):
+        """Fields as a length-4 numpy array."""
+        return np.array([self.clip_a, self.clip_b, self.mean, self.std])
+
+
+@dataclass
+class CurvePriors:
+    """Set of priors for fitting a single curve."""
+
+    amp: PriorFields = None
+    beta: PriorFields = None
+    gamma: PriorFields = None
+    t_0: PriorFields = None
+    tau_rise: PriorFields = None
+    tau_fall: PriorFields = None
+    extra_sigma: PriorFields = None
+
+    def __post_init__(self):
+        """Additional logic to coerce string dictionaries into the appropriate
+        data type."""
+        if isinstance(self.amp, dict):
+            self.amp = PriorFields(**self.amp)
+            self.beta = PriorFields(**self.beta)
+            self.gamma = PriorFields(**self.gamma)
+            self.t_0 = PriorFields(**self.t_0)
+            self.tau_rise = PriorFields(**self.tau_rise)
+            self.tau_fall = PriorFields(**self.tau_fall)
+            self.extra_sigma = PriorFields(**self.extra_sigma)
+
+    def to_numpy(self):
+        """Fields as a 7x4 numpy array"""
+        return [
+            self.amp.to_numpy(),
+            self.beta.to_numpy(),
+            self.gamma.to_numpy(),
+            self.t_0.to_numpy(),
+            self.tau_rise.to_numpy(),
+            self.tau_fall.to_numpy(),
+            self.extra_sigma.to_numpy(),
+        ]
+
+
+@dataclass
+class MultibandPriors:
+    """Set of per-band curve priors"""
+
+    bands: Dict[str, CurvePriors] = field(default_factory=dict)
+    """Per-band curve priors."""
+    band_order: str = "ugrizy"
+    """Ordering of bands."""
+
+    def __post_init__(self):
+        """Additional logic to coerce string dictionaries into the appropriate
+        data type."""
+        for band, curve_priors in self.bands.items():
+            if isinstance(curve_priors, CurvePriors):
+                pass
+            elif isinstance(curve_priors, dict):
+                self.bands[band] = CurvePriors(**curve_priors)
+
+    # def get_clip_a(self):
+
+    def to_numpy(self):
+        """Fields as a (7*bands)x4 numpy array"""
+        priors = []
+        for band in self.band_order:
+            if band in self.bands:
+                priors.append(self.bands[band].to_numpy())
+
+        return np.concatenate(priors)
+
+    def write_to_file(self, file: str):
+        """Write per-band curve priors to a yaml file."""
+        args = dataclasses.asdict(self)
+        encoded_string = yaml.dump(args, sort_keys=False)
+        with open(file, "w", encoding="utf-8") as file:
+            file.write(encoded_string)
+
+    @classmethod
+    def from_file(cls, file: str) -> Self:
+        """Read per-band curve priors from a yaml file."""
+        with open(file, "r", encoding="utf-8") as file:
+            metadata = yaml.safe_load(file)
+            return cls(**metadata)
+
+    @classmethod
+    def load_ztf_priors(cls) -> Self:
+        """Read ZTF priors from neighboring file."""
+        package_filepath = os.path.dirname(superphot_plus.__file__)
+        ztf_path = os.path.join(package_filepath, "priors", "ztf_rg_priors.yaml")
+        return cls.from_file(ztf_path)

--- a/src/superphot_plus/priors/ztf_rg_priors.yaml
+++ b/src/superphot_plus/priors/ztf_rg_priors.yaml
@@ -1,0 +1,74 @@
+band_order: rg
+bands:
+  r:
+    amp:
+      clip_a: -0.2
+      clip_b: 1.2
+      mean: 0
+      std: 0.5
+    beta:
+      clip_a: 0.0
+      clip_b: 0.2
+      mean: 0.0052
+      std: 0.000504
+    gamma:
+      clip_a: -2.0
+      clip_b: 2.5
+      mean: 1.1391
+      std: 0.25785
+    t_0:
+      clip_a: -100.0
+      clip_b: 200.0
+      mean: 0
+      std: 50
+    tau_rise:
+      clip_a: -1.0
+      clip_b: 3.0
+      mean: 0.599
+      std: 0.31095
+    tau_fall:
+      clip_a: 0.5
+      clip_b: 4.0
+      mean: 1.4296
+      std: 0.15045
+    extra_sigma:
+      clip_a: -5.0
+      clip_b: -0.5
+      mean: -1.5364
+      std: 0.2691
+  g:
+    amp:
+      clip_a: 0
+      clip_b: 5.0
+      mean: 1.0607
+      std: 0.2316
+    beta:
+      clip_a: 1.0
+      clip_b: 1.07
+      mean: 1.0424
+      std: 0.0026
+    gamma:
+      clip_a: 0.8
+      clip_b: 1.2
+      mean: 1.0075
+      std: 0.0139
+    t_0:
+      clip_a: 0.9994
+      clip_b: 1.0006
+      mean: 0.999989
+      std: 0.000067
+    tau_rise:
+      clip_a: 0.5
+      clip_b: 2.0
+      mean: 0.9663
+      std: 0.0128
+    tau_fall:
+      clip_a: 0.1
+      clip_b: 3.0
+      mean: 0.5488
+      std: 0.0553
+    extra_sigma:
+      clip_a: 0.2
+      clip_b: 2.0
+      mean: 0.8606
+      std: 0.0388

--- a/tests/superphot_plus/test_fitting_priors.py
+++ b/tests/superphot_plus/test_fitting_priors.py
@@ -1,0 +1,45 @@
+import os
+
+import numpy as np
+
+from superphot_plus.priors.fitting_priors import CurvePriors, MultibandPriors, PriorFields
+
+
+def test_write_to_file(tmp_path) -> None:
+    default = MultibandPriors(
+        {
+            "r": CurvePriors(
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+            ),
+            "g": CurvePriors(
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+                PriorFields(),
+            ),
+        }
+    )
+
+    default.write_to_file(os.path.join(tmp_path, "empty_priors.yaml"))
+    read_values = MultibandPriors.from_file(os.path.join(tmp_path, "empty_priors.yaml"))
+    assert read_values == default
+
+
+def test_read_survey_priors():
+    ztf_priors = MultibandPriors.load_ztf_priors()
+
+    assert len(ztf_priors.bands) == 2
+
+
+def test_to_numpy():
+    ztf_priors = MultibandPriors.load_ztf_priors()
+    assert np.isclose(ztf_priors.to_numpy().sum(), 181.5, atol=0.2)


### PR DESCRIPTION
## Change Description

Related to issue #64.

Creates a set of dataclasses to hold the per-band priors for curve fitting parameters.

Notes:
- removes the r and g priors from the constants file, as they're now mostly unused
- lets us use explicit imports for the handful of remaining constants use
- skips migrating constants use in `make_fake_spp_data` for now, because I got lazy
- we can augment the MultibandPriors with additional per-survey configuration (e.g. which bands are "primary" and which are "auxiliary", etc).

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation