### PR TITLE
README: add venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ To install this package for development use:
 ```
 $ git clone http://github.com/lincc-frameworks/superphot-plus
 $ cd superphot-plus
-$ pip install -e .
-$ pip install -e ".[dev]"
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ python -m pip install -e ".[dev]"
 ```
 
 You can then run `$ pytest` to verify that all dependencies are correct,


### PR DESCRIPTION
## Change Description
Update the shell code snippet in "Getting started" with virtual environment instructions. I also removes "pip install ." because installation with "dev" extras should also install the base version of the package
