### PR TITLE
Use tmp_path pytest fixture for test  output.

### DIFF
--- a/tests/superphot_plus/test_plotting.py
+++ b/tests/superphot_plus/test_plotting.py
@@ -3,17 +3,11 @@ import os
 import numpy as np
 import pytest
 
-from superphot_plus.file_utils import get_posterior_samples
-from superphot_plus.fit_numpyro import main_loop_directory
-from superphot_plus.lightcurve import Lightcurve
-from superphot_plus.plotting import (
-    plot_posterior_hist,
-    plot_sampling_lc_fit_numpyro,
-    plot_sampling_trace_numpyro,
-)
+from superphot_plus.plotting import plot_posterior_hist, plot_sampling_trace_numpyro
 
 
 def generate_dummy_posterior_sample_dict(batch=False):
+    """Create a posterior sample dictionary for r and g bands with random values"""
     param_list = [
         "logA",
         "beta",
@@ -35,45 +29,42 @@ def generate_dummy_posterior_sample_dict(batch=False):
     }
 
 
-def test_plot_posterior_hist(test_data_dir):
+def test_plot_posterior_hist(tmp_path):
     """Test that we can plot a posterior samples histogram."""
     samples = generate_dummy_posterior_sample_dict()
 
     # Check that plot is created for a valid parameter.
     parameter = "log_tau_fall"
 
-    plot_posterior_hist(samples, parameter, test_data_dir)
+    plot_posterior_hist(samples, parameter, tmp_path)
 
-    filepath = os.path.join(test_data_dir, f"test_hist_{parameter}.png")
+    filepath = os.path.join(tmp_path, f"test_hist_{parameter}.png")
     assert os.path.exists(filepath)
-    os.remove(filepath)
 
     # Check that plot throws an error if parameter is not valid.
     with pytest.raises(ValueError):
-        plot_posterior_hist(samples, "test", test_data_dir)
-        plot_posterior_hist(samples, None, test_data_dir)
+        plot_posterior_hist(samples, "test", tmp_path)
+        plot_posterior_hist(samples, None, tmp_path)
 
 
-def test_plot_posterior_hist_batch(test_data_dir):
+def test_plot_posterior_hist_batch(tmp_path):
     """Test that we can plot a histogram for a batch of posterior samples."""
     samples = generate_dummy_posterior_sample_dict(batch=True)
 
     # Check that plot is created for a valid parameter.
     parameter = "log_tau_fall"
 
-    plot_posterior_hist(samples, parameter, test_data_dir)
+    plot_posterior_hist(samples, parameter, tmp_path)
 
-    filepath = os.path.join(test_data_dir, f"test_hist_{parameter}.png")
+    filepath = os.path.join(tmp_path, f"test_hist_{parameter}.png")
     assert os.path.exists(filepath)
-    os.remove(filepath)
 
 
-def test_plot_sampling_trace_numpyro(test_data_dir):
+def test_plot_sampling_trace_numpyro(tmp_path):
     """Test that we can plot the trace of posterior samples."""
     samples = generate_dummy_posterior_sample_dict(batch=True)
 
-    plot_sampling_trace_numpyro(samples, test_data_dir)
+    plot_sampling_trace_numpyro(samples, tmp_path)
 
-    filepath = os.path.join(test_data_dir, "test_trace.png")
+    filepath = os.path.join(tmp_path, "test_trace.png")
     assert os.path.exists(filepath)
-    os.remove(filepath)


### PR DESCRIPTION
## Change Description

Closes issue #81.

While checking existing use of `test_data_dir`, it took some tracking down to figure out which parameters were input or output directories. I may have a follow-up PR to change names e.g. `fits_dir` -> `output_fits_dir`.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation