### PR TITLE
Move the lightcurve file functions into Lightcurve

### DIFF
--- a/src/superphot_plus/classify_ztf.py
+++ b/src/superphot_plus/classify_ztf.py
@@ -351,7 +351,6 @@ def return_new_classifications(test_csv, data_dirs, fit_dir, include_labels=Fals
         csv_reader = csv.reader(tc, delimiter=",")
         next(csv_reader)
         for _, row in enumerate(csv_reader):
-
             try:
                 test_name = row[0]
             except:

--- a/src/superphot_plus/data_generation/make_fake_spp_data.py
+++ b/src/superphot_plus/data_generation/make_fake_spp_data.py
@@ -23,6 +23,7 @@ PRIOR_TAU_RISE_g = [0.5, 2.0, 0.9663, 0.0128]
 PRIOR_TAU_FALL_g = [0.1, 3.0, 0.5488, 0.0553]
 PRIOR_EXTRA_SIGMA_g = [0.2, 2.0, 0.8606, 0.0388]
 
+
 def trunc_gauss(quantile, clip_a, clip_b, mean, std):
     """Truncated Gaussian distribution.
 
@@ -47,6 +48,7 @@ def trunc_gauss(quantile, clip_a, clip_b, mean, std):
     """
     a, b = (clip_a - mean) / std, (clip_b - mean) / std
     return truncnorm.ppf(quantile, a, b, loc=mean, scale=std)
+
 
 def create_prior(cube):
     """Creates prior for dynesty, where each side of the "cube"

--- a/src/superphot_plus/file_utils.py
+++ b/src/superphot_plus/file_utils.py
@@ -47,37 +47,6 @@ def read_single_lightcurve(filename, time_ceiling=None):
     return t, f, ferr, b
 
 
-def save_single_lightcurve(filename, times, fluxes, errors, bands, compressed=True, overwrite=False):
-    """
-    Write a single lightcurve data file.
-
-    Parameters
-    ----------
-    filename : str
-        Name of the data file including path.
-    times : array-like
-        The light curve time data.
-    fluxes : array-like
-        The light curve flux data.
-    errors : array-like
-        The light curve error data.
-    bands : array-like
-        The light curve band data.
-    compressed : bool, optional
-        Whether to save in compressed format.
-    overwrite : bool, optional
-        Whether to overwrite existing data.
-    """
-    if os.path.exists(filename) and not overwrite:
-        raise FileExistsError(f"ERROR: File already exists {filename}")
-
-    lcs = np.array([times, fluxes, errors, bands])
-    if compressed:
-        np.savez_compressed(filename, lcs)
-    else:
-        np.savez(filename, lcs)
-
-
 def get_posterior_filename(lc_name, fits_dir=None, sampler=None):
     """Get the file name for equal weight posterior samples from a lightcurve fit.
 

--- a/src/superphot_plus/file_utils.py
+++ b/src/superphot_plus/file_utils.py
@@ -7,46 +7,6 @@ import numpy as np
 from superphot_plus.file_paths import FITS_DIR
 
 
-def read_single_lightcurve(filename, time_ceiling=None):
-    """
-    Import a compressed lightcurve data file.
-
-    Parameters
-    ----------
-    filename : str
-        Name of the data file.
-    time_ceiling : float, optional
-        Upper limit for time, and any points in the light curve after this ceiling
-        will be dropped. Defaults to None and all points are returned.
-
-    Returns
-    -------
-    tuple
-        Tuple containing the imported data (t, f, ferr, b).
-    """
-    npy_array = np.load(filename)
-    arr = npy_array["arr_0"]
-
-    ferr = arr[2]
-    t = arr[0][ferr != "nan"].astype(float)
-    f = arr[1][ferr != "nan"].astype(float)
-    b = arr[3][ferr != "nan"]
-    ferr = ferr[ferr != "nan"].astype(float)
-
-    if time_ceiling is not None:
-        f = f[t <= time_ceiling]
-        b = b[t <= time_ceiling]
-        ferr = ferr[t <= time_ceiling]
-        t = t[t <= time_ceiling]
-
-    if len(t) > 0:
-        max_flux_loc = t[b == "r"][np.argmax(f[b == "r"] - np.abs(ferr[b == "r"]))]
-
-        t -= max_flux_loc  # make relative
-
-    return t, f, ferr, b
-
-
 def get_posterior_filename(lc_name, fits_dir=None, sampler=None):
     """Get the file name for equal weight posterior samples from a lightcurve fit.
 

--- a/src/superphot_plus/fit_numpyro.py
+++ b/src/superphot_plus/fit_numpyro.py
@@ -416,7 +416,6 @@ def run_mcmc_batch(lcs, t0_lim=None, plot=False):
             Index values for the band. Defaults to None.
         """
         with numpyro.plate("components", N) as sn_index:  # pylint: disable=unused-variable
-
             all_priors = MultibandPriors.load_ztf_priors()
             r_priors = all_priors.bands["r"]
             A = max_flux * 10 ** numpyro.sample("logA", trunc_norm_fields(r_priors.amp))

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -83,7 +83,7 @@ class Lightcurve:
         else:
             ref_band = self.bands == band
         if np.all(ref_band == False) or len(self.bands) == 0:
-            raise ValueError(f"ERROR: Light curve has no points (band={band})")
+            raise ValueError(f"ERROR: Light curve has no points. band={band}")
 
         adjusted_flux = self.fluxes[ref_band] + error_coeff * np.abs(self.flux_errors[ref_band])
         max_index = np.argmax(adjusted_flux)

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -2,8 +2,6 @@
 import numpy as np
 import os
 
-from superphot_plus.file_utils import read_single_lightcurve
-
 
 class Lightcurve:
     def __init__(self, times, fluxes, flux_errors, bands, name=None, sn_class=None):
@@ -85,7 +83,7 @@ class Lightcurve:
         else:
             ref_band = self.bands == band
         if np.all(ref_band == False) or len(self.bands) == 0:
-            raise ValueError(f"ERROR: Light curve has no points. band={band}")
+            raise ValueError(f"ERROR: Light curve has no points (band={band})")
 
         adjusted_flux = self.fluxes[ref_band] + error_coeff * np.abs(self.flux_errors[ref_band])
         max_index = np.argmax(adjusted_flux)

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -1,7 +1,8 @@
 """A data class for storing information for a single light curve."""
 import numpy as np
+import os
 
-from superphot_plus.file_utils import read_single_lightcurve, save_single_lightcurve
+from superphot_plus.file_utils import read_single_lightcurve
 
 
 class Lightcurve:
@@ -189,10 +190,16 @@ class Lightcurve:
             The file name to use.
         overwrite : bool, optional
             Overwrite existing files.
+
+        Raises
+        ------
+        FileExistsError if the file exists and overwrite is False.
         """
-        save_single_lightcurve(
-            filename, self.times, self.fluxes, self.flux_errors, self.bands, overwrite=overwrite
-        )
+        if os.path.exists(filename) and not overwrite:
+            raise FileExistsError(f"ERROR: File already exists {filename}")
+
+        lcs = np.array([times, fluxes, errors, bands])
+        np.savez_compressed(filename, lcs)
 
     @classmethod
     def from_file(cls, filename, t0_lim=None):

--- a/src/superphot_plus/priors/fitting_priors.py
+++ b/src/superphot_plus/priors/fitting_priors.py
@@ -86,9 +86,9 @@ class MultibandPriors:
         for band in self.band_order:
             if band in self.bands:
                 bands_ordered.append(band)
-        
+
         return np.array(bands_ordered)
-    
+
     def to_numpy(self):
         """Fields as a (7*bands)x4 numpy array"""
         priors = []

--- a/src/superphot_plus/utils.py
+++ b/src/superphot_plus/utils.py
@@ -166,9 +166,11 @@ def flux_model(cube, t_data, b_data, ordered_bands, ref_band):
     """
     b_data = np.array(b_data)
     ref_band_idx = np.argmax(ref_band == np.array(ordered_bands))
-    start_idx = ref_band_idx*7
-    
-    A, beta, gamma, t0, tau_rise, tau_fall, es = cube[start_idx:start_idx+7]  # pylint: disable=unused-variable
+    start_idx = ref_band_idx * 7
+
+    A, beta, gamma, t0, tau_rise, tau_fall, es = cube[
+        start_idx : start_idx + 7
+    ]  # pylint: disable=unused-variable
     phase = t_data - t0
     f_model = (
         A / (1.0 + np.exp(-phase / tau_rise)) * (1.0 - beta * gamma) * np.exp((gamma - phase) / tau_fall)
@@ -180,7 +182,7 @@ def flux_model(cube, t_data, b_data, ordered_bands, ref_band):
     for band_idx, ordered_band in enumerate(ordered_bands):
         if ordered_band == ref_band:
             continue
-        start_idx = 7*band_idx
+        start_idx = 7 * band_idx
         A_b = A * cube[start_idx]
         beta_b = beta * cube[start_idx + 1]
         gamma_b = gamma * cube[start_idx + 2]
@@ -188,7 +190,7 @@ def flux_model(cube, t_data, b_data, ordered_bands, ref_band):
         tau_rise_b = tau_rise * cube[start_idx + 4]
         tau_fall_b = tau_fall * cube[start_idx + 5]
 
-        inc_band_ix = (b_data == ordered_band)
+        inc_band_ix = b_data == ordered_band
         phase_b = (t_data - t0_b)[inc_band_ix]
         phase_b2 = (t_data - t0_b)[inc_band_ix & (t_data - t0_b < gamma_b)]
 
@@ -201,11 +203,11 @@ def flux_model(cube, t_data, b_data, ordered_bands, ref_band):
         f_model[inc_band_ix & (t_data - t0_b < gamma_b)] = (
             A_b / (1.0 + np.exp(-phase_b2 / tau_rise_b)) * (1.0 - phase_b2 * beta_b)
         )
-        
+
     return f_model
 
 
-def calculate_neg_chi_squareds(cubes, t, f, ferr, b, ordered_bands=["r","g"], ref_band="r"):
+def calculate_neg_chi_squareds(cubes, t, f, ferr, b, ordered_bands=["r", "g"], ref_band="r"):
     """Gets the negative chi-squared of posterior fits from the model
     parameters and original data files.
 
@@ -227,7 +229,9 @@ def calculate_neg_chi_squareds(cubes, t, f, ferr, b, ordered_bands=["r","g"], re
     log_likelihoods : np.ndarray
         The log likelihoods for each object.
     """
-    model_f = np.array([flux_model(cube, t, b, ordered_bands, ref_band) for cube in cubes])  # in future, maybe vectorize flux_model
+    model_f = np.array(
+        [flux_model(cube, t, b, ordered_bands, ref_band) for cube in cubes]
+    )  # in future, maybe vectorize flux_model
     extra_sigma_arr = np.ones((len(cubes), len(t))) * np.max(f[b == "r"]) * cubes[:, 6][:, np.newaxis]
     extra_sigma_arr[:, b == "g"] *= cubes[:, -2][:, np.newaxis]
     sigma_sq = extra_sigma_arr**2 + ferr**2

--- a/src/superphot_plus/ztf_transient_fit.py
+++ b/src/superphot_plus/ztf_transient_fit.py
@@ -185,7 +185,9 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None, telescope="ZTF"):
             extra_sigma_arr[lc.bands == ordered_band] *= cube[7 * band_idx + 6]
 
         sigma_sq = lc.flux_errors**2 + extra_sigma_arr**2
-        logL = np.sum(np.log(1.0 / np.sqrt(2.0 * np.pi * sigma_sq)) - 0.5 * (f_model - fdata) ** 2 / sigma_sq)
+        logL = np.sum(
+            np.log(1.0 / np.sqrt(2.0 * np.pi * sigma_sq)) - 0.5 * (f_model - lc.fluxes) ** 2 / sigma_sq
+        )
         return logL
 
     st = time.time()  # pylint: disable=unused-variable
@@ -208,7 +210,9 @@ def run_mcmc(lc, t0_lim=None, plot=False, rstate=None, telescope="ZTF"):
     if plot:  # pragma: no cover
         if lc.name is None:
             raise ValueError("Missing file name for plotting files.")
-        plot_sampling_lc_fit(lc.name, FIT_PLOTS_FOLDER, lc.times, lc.fluxes, lc.flux_errors, lc.bands, eq_wt_samples)
+        plot_sampling_lc_fit(
+            lc.name, FIT_PLOTS_FOLDER, lc.times, lc.fluxes, lc.flux_errors, lc.bands, eq_wt_samples
+        )
 
     return eq_wt_samples
 

--- a/tests/superphot_plus/test_file_utils.py
+++ b/tests/superphot_plus/test_file_utils.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 
-from superphot_plus.file_utils import get_posterior_samples, read_single_lightcurve, save_single_lightcurve
+from superphot_plus.file_utils import get_posterior_samples, read_single_lightcurve
 
 
 def test_read_single_lightcurve(single_ztf_lightcurve_compressed):
@@ -15,48 +15,6 @@ def test_read_single_lightcurve(single_ztf_lightcurve_compressed):
     assert len(flux) == 19
     assert len(flux_err) == 19
     assert len(band) == 19
-
-
-def test_write_and_read_single_lightcurve(tmp_path):
-    # Create fake data. Note that the first point in the fluxes must be the brightest
-    # and the first time stamp must be zero, because of how read_single_lightcurve
-    # shifts the times to be zero at the peak.
-    times = np.array(range(10))
-    fluxes = np.array([100.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1])
-    bands = np.array(["r"] * 10)
-    errors = np.array([0.1] * 10)
-
-    filename = os.path.join(tmp_path, "my_test_file.npz")
-    save_single_lightcurve(filename, times, fluxes, errors, bands, overwrite=True)
-
-    # Re-read and check data.
-    t2, f2, e2, b2 = read_single_lightcurve(filename)
-    assert np.allclose(t2, times)
-    assert np.allclose(f2, fluxes)
-    assert np.allclose(e2, errors)
-
-    # If we try to save again (without overwrite=True) we should get an error.
-    with pytest.raises(FileExistsError):
-        save_single_lightcurve(filename, times, fluxes, errors, bands, overwrite=False)
-
-
-def test_write_and_read_uncompressed_lightcurve(tmp_path):
-    # Create fake data. Note that the first point in the fluxes must be the brightest
-    # and the first time stamp must be zero, because of how read_single_lightcurve
-    # shifts the times to be zero at the peak.
-    times = np.array(range(10))
-    fluxes = np.array([100.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1])
-    bands = np.array(["r"] * 10)
-    errors = np.array([0.1] * 10)
-
-    filename = os.path.join(tmp_path, "my_test_file.npz")
-    save_single_lightcurve(filename, times, fluxes, errors, bands, compressed=False, overwrite=True)
-
-    # Re-read and check data.
-    t2, f2, e2, b2 = read_single_lightcurve(filename)
-    assert np.allclose(t2, times)
-    assert np.allclose(f2, fluxes)
-    assert np.allclose(e2, errors)
 
 
 def test_read_single_lightcurve_with_time_celing(single_ztf_lightcurve_compressed):

--- a/tests/superphot_plus/test_file_utils.py
+++ b/tests/superphot_plus/test_file_utils.py
@@ -3,43 +3,7 @@ import os
 import numpy as np
 import pytest
 
-from superphot_plus.file_utils import get_posterior_samples, read_single_lightcurve
-
-
-def test_read_single_lightcurve(single_ztf_lightcurve_compressed):
-    """Test that we can load a single light curve from pickled file."""
-
-    time, flux, flux_err, band = read_single_lightcurve(single_ztf_lightcurve_compressed)
-
-    assert len(time) == 19
-    assert len(flux) == 19
-    assert len(flux_err) == 19
-    assert len(band) == 19
-
-
-def test_read_single_lightcurve_with_time_celing(single_ztf_lightcurve_compressed):
-    """Test that we can load a single light curve from pickled file,
-    restricting the time window for events."""
-
-    ## nonsense time.
-    time, flux, flux_err, band = read_single_lightcurve(single_ztf_lightcurve_compressed, time_ceiling=45.0)
-
-    expected_length = 0
-    assert len(time) == expected_length
-    assert len(flux) == expected_length
-    assert len(flux_err) == expected_length
-    assert len(band) == expected_length
-
-    ## time somewhere within the light curve.
-    time, flux, flux_err, band = read_single_lightcurve(
-        single_ztf_lightcurve_compressed, time_ceiling=59932.0
-    )
-
-    expected_length = 15
-    assert len(time) == expected_length
-    assert len(flux) == expected_length
-    assert len(flux_err) == expected_length
-    assert len(band) == expected_length
+from superphot_plus.file_utils import get_posterior_samples
 
 
 def test_get_posterior_samples(single_ztf_sn_id, single_ztf_eqwt_compressed, test_data_dir):

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -87,6 +87,7 @@ def test_write_and_read_single_lightcurve(tmp_path):
     assert np.allclose(t2, times)
     assert np.allclose(f2, fluxes)
     assert np.allclose(e2, errors)
+    assert np.all(b2 == bands)
 
 
 def test_sort():

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -3,7 +3,6 @@ import os
 import numpy as np
 import pytest
 
-from superphot_plus.file_utils import read_single_lightcurve
 from superphot_plus.lightcurve import Lightcurve
 
 
@@ -55,7 +54,7 @@ def test_max_flux():
     assert r_max_t == 5
 
     # Test y band gives an error
-    with pytest.raises(ValueError, match=r"ERROR: Light curve has no points. band=y"):
+    with pytest.raises(ValueError, match="ERROR: Light curve has no points \(band=y\)"):
         _, _ = lc.find_max_flux(band="y", error_coeff=0.0)
 
 
@@ -71,6 +70,7 @@ def test_from_file(single_ztf_lightcurve_compressed):
     # Fail when file does not exist.
     with pytest.raises(FileNotFoundError, match="ERROR: File does not exist file_does_not_exist.err"):
         _ = Lightcurve.from_file("file_does_not_exist.err")
+
 
 def test_write_and_read_single_lightcurve(tmp_path):
     # Create fake data. Note that the first point in the fluxes must be the brightest
@@ -98,6 +98,7 @@ def test_write_and_read_single_lightcurve(tmp_path):
     assert np.all(lc3.times <= 5.0)
     assert len(lc3.fluxes) == 6
 
+
 def test_write_and_read_single_lightcurve_no_shift(tmp_path):
     # Create fake data. Note that the first point in the fluxes must be the brightest
     # and the first time stamp must be zero, because of how read_single_lightcurve
@@ -124,6 +125,7 @@ def test_write_and_read_single_lightcurve_no_shift(tmp_path):
     # If we do shift then hald the times should be < 0.
     lc3 = Lightcurve.from_file(filename, shift_time=True)
     assert np.allclose(lc3.times, range(-4, 6))
+
 
 def test_write_and_read_single_lightcurve_nans(tmp_path):
     times = np.array(range(8))

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -54,7 +54,7 @@ def test_max_flux():
     assert r_max_t == 5
 
     # Test y band gives an error
-    with pytest.raises(ValueError, match="ERROR: Light curve has no points \(band=y\)"):
+    with pytest.raises(ValueError, match=r"ERROR: Light curve has no points. band=y"):
         _, _ = lc.find_max_flux(band="y", error_coeff=0.0)
 
 

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -68,6 +68,9 @@ def test_from_file(single_ztf_lightcurve_compressed):
     assert len(lc.bands) == 19
     assert lc.name == "ZTF22abvdwik"
 
+    # Fail when file does not exist.
+    with pytest.raises(FileNotFoundError, match="ERROR: File does not exist file_does_not_exist.err"):
+        _ = Lightcurve.from_file("file_does_not_exist.err")
 
 def test_write_and_read_single_lightcurve(tmp_path):
     # Create fake data. Note that the first point in the fluxes must be the brightest
@@ -83,11 +86,62 @@ def test_write_and_read_single_lightcurve(tmp_path):
     lc.save_to_file(filename, overwrite=True)
 
     # Re-read and check data.
-    t2, f2, e2, b2 = read_single_lightcurve(filename)
-    assert np.allclose(t2, times)
-    assert np.allclose(f2, fluxes)
-    assert np.allclose(e2, errors)
-    assert np.all(b2 == bands)
+    lc2 = Lightcurve.from_file(filename)
+    assert lc2.name == "my_test_file"
+    assert np.allclose(lc2.times, times)
+    assert np.allclose(lc2.fluxes, fluxes)
+    assert np.allclose(lc2.flux_errors, errors)
+    assert np.all(lc2.bands == bands)
+
+    # Read the data with a t0_lim of 5.0
+    lc3 = Lightcurve.from_file(filename, t0_lim=5.0)
+    assert np.all(lc3.times <= 5.0)
+    assert len(lc3.fluxes) == 6
+
+def test_write_and_read_single_lightcurve_no_shift(tmp_path):
+    # Create fake data. Note that the first point in the fluxes must be the brightest
+    # and the first time stamp must be zero, because of how read_single_lightcurve
+    # shifts the times to be zero at the peak.
+    times = np.array(range(10))
+    fluxes = np.array([0.1, 0.2, 0.3, 0.1, 100.2, 0.3, 0.1, 0.1, 0.1, 0.1])
+    bands = np.array(["r"] * 10)
+    errors = np.array([0.1] * 10)
+    lc = Lightcurve(times, fluxes, errors, bands, name="my_test_file2")
+
+    filename = os.path.join(tmp_path, "my_test_file2.npz")
+    lc.save_to_file(filename, overwrite=True)
+
+    # Re-read and check data.
+    lc2 = Lightcurve.from_file(filename, shift_time=False)
+    assert lc.name == "my_test_file2"
+    assert np.allclose(lc2.times, times)
+    assert np.allclose(lc2.fluxes, fluxes)
+    assert np.allclose(lc2.flux_errors, errors)
+    print(bands)
+    print(lc2.bands)
+    assert np.all(lc2.bands == bands)
+
+    # If we do shift then hald the times should be < 0.
+    lc3 = Lightcurve.from_file(filename, shift_time=True)
+    assert np.allclose(lc3.times, range(-4, 6))
+
+def test_write_and_read_single_lightcurve_nans(tmp_path):
+    times = np.array(range(8))
+    fluxes = np.array([0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.0])
+    bands = np.array(["g"] * 8)
+    errors = np.array([0.1, 0.1, 0.1, 0.1, np.NAN, 0.1, np.NAN, 0.2])
+    lc = Lightcurve(times, fluxes, errors, bands, name="my_nan_test_file")
+
+    filename = os.path.join(tmp_path, "my_nan_test_file.npz")
+    lc.save_to_file(filename, overwrite=True)
+
+    # Re-read and check data.
+    lc2 = Lightcurve.from_file(filename)
+    assert lc2.name == "my_nan_test_file"
+    assert np.allclose(lc2.times, [0.0, 1.0, 2.0, 3.0, 5.0, 7.0])
+    assert np.allclose(lc2.fluxes, [0.1, 0.2, 0.3, 0.1, 0.3, 0.0])
+    assert np.allclose(lc2.flux_errors, [0.1, 0.1, 0.1, 0.1, 0.1, 0.2])
+    assert np.all(lc2.bands == ["g"] * 6)
 
 
 def test_sort():

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -118,8 +118,6 @@ def test_write_and_read_single_lightcurve_no_shift(tmp_path):
     assert np.allclose(lc2.times, times)
     assert np.allclose(lc2.fluxes, fluxes)
     assert np.allclose(lc2.flux_errors, errors)
-    print(bands)
-    print(lc2.bands)
     assert np.all(lc2.bands == bands)
 
     # If we do shift then hald the times should be < 0.

--- a/tests/superphot_plus/test_utils.py
+++ b/tests/superphot_plus/test_utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from superphot_plus.file_utils import get_posterior_samples, read_single_lightcurve
+from superphot_plus.file_utils import get_posterior_samples
+from superphot_plus.lightcurve import Lightcurve
 from superphot_plus.utils import calc_accuracy, calculate_neg_chi_squareds, f1_score, get_band_extinctions
 
 
@@ -65,6 +66,8 @@ def test_neg_chi_squareds(single_ztf_lightcurve_compressed, test_data_dir, singl
     the function runs correctly returns the same value as it used to.
     """
     posts = get_posterior_samples(single_ztf_sn_id, fits_dir=test_data_dir, sampler="dynesty")
-    sn_data = read_single_lightcurve(single_ztf_lightcurve_compressed)
+    lc = Lightcurve.from_file(single_ztf_lightcurve_compressed)
+
+    sn_data = [lc.times, lc.fluxes, lc.flux_errors, lc.bands]
     result = calculate_neg_chi_squareds(posts, *sn_data)
     assert np.isclose(np.mean(result), -5.43, rtol=0.1)


### PR DESCRIPTION
Moves the function to read and write lightcurves from file_utils into the `Lightcurve` object. Also adds options for zero shifting the time (to make the operation explicit) and for passing in a reference band (instead of defaulting to "r").

PR includes a bunch of additional clean ups including black formatting, replacing individual vectors (`tdata`, `fdata`, etc.) with a `Lightcurve` object.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation