### PR TITLE
Provide helper functions for working with bands in Lightcurve

### DIFF
--- a/src/superphot_plus/fit_numpyro.py
+++ b/src/superphot_plus/fit_numpyro.py
@@ -385,7 +385,7 @@ def run_mcmc_batch(lcs, t0_lim=None, plot=False):
         tdata_stacked.append(lc.times)
         fdata_stacked.append(lc.fluxes)
         ferrdata_stacked.append(lc.flux_errors)
-        bdata_stacked.append(lc.band_as_int(["r", "g"]))  # change to integers
+        bdata_stacked.append(lc.band_as_int(["g", "r"]))  # change to integers
 
     tdata_stacked = np.array(tdata_stacked)
     fdata_stacked = np.array(fdata_stacked)

--- a/src/superphot_plus/fit_numpyro.py
+++ b/src/superphot_plus/fit_numpyro.py
@@ -106,7 +106,7 @@ def run_mcmc(lc, sampler="NUTS", t0_lim=None, plot=False):
     tdata = lc.times
     fdata = lc.fluxes
     ferrdata = lc.flux_errors
-    bdata = np.where(lc.bands == "r", ref_band_idx, 1 - ref_band_idx)  # change to integers
+    bdata = lc.band_as_int(["g", "r"])  # change to integers
 
     max_flux = np.max(fdata[PAD_SIZE:] - np.abs(ferrdata[PAD_SIZE:]))
     inc_band_ix = np.arange(0, PAD_SIZE)
@@ -385,7 +385,7 @@ def run_mcmc_batch(lcs, t0_lim=None, plot=False):
         tdata_stacked.append(lc.times)
         fdata_stacked.append(lc.fluxes)
         ferrdata_stacked.append(lc.flux_errors)
-        bdata_stacked.append(np.where(lc.bands == "r", ref_band_idx, 1 - ref_band_idx))  # change to integers
+        bdata_stacked.append(lc.band_as_int(["r", "g"]))  # change to integers
 
     tdata_stacked = np.array(tdata_stacked)
     fdata_stacked = np.array(fdata_stacked)

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -188,7 +188,7 @@ class Lightcurve:
 
         Raises
         ------
-        ValueError is a band in the light curve is not included in ordered_bands
+        ValueError if a band in the light curve is not included in ordered_bands
         and fail_on_missing is True.
         """
         if not np.all(np.isin(self.bands, ordered_bands)) and fail_on_missing:

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -165,7 +165,7 @@ class Lightcurve:
         Returns
         -------
         result : Lightcurve
-            The padded lightcurve. Returns self if in_place == True.
+            The filtered lightcurve. Returns self if in_place == True.
         """
         keep_row = np.isin(self.bands, keep_bands)
         return self._reindex(keep_row, in_place=in_place)

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -36,6 +36,41 @@ class Lightcurve:
         self.name = name
         self.sn_class = sn_class
 
+    def _reindex(self, indices, in_place=True):
+        """Rearrange or subset the values in each array to match
+        the ordering provided by indices.
+
+        Parameters
+        ----------
+        indices : array_like
+            This can either be an array-like of integer indices to keep
+            and the order in which to put them or an array-like of bools
+            that indicate whether to each each entry.
+        in_place : bool
+            A Boolean indicating whether to modify the data in-place or
+            make a new copy of the light curve.
+
+        Returns
+        -------
+        result : Lightcurve
+            The resulting Lightcurve. Returns self if in_place == True.
+        """
+        if in_place:
+            self.times = self.times[indices]
+            self.fluxes = self.fluxes[indices]
+            self.flux_errors = self.flux_errors[indices]
+            self.bands = self.bands[indices]
+            return self
+        else:
+            return Lightcurve(
+                self.times[indices],
+                self.fluxes[indices],
+                self.flux_errors[indices],
+                self.bands[indices],
+                name=self.name,
+                sn_class=self.sn_class,
+            )
+
     def obs_count(self, band=None):
         """Return the count of observations (in a given band).
 
@@ -53,6 +88,16 @@ class Lightcurve:
             return len(self.times)
         else:
             return np.count_nonzero(self.bands == band)
+
+    def unique_bands(self):
+        """Return a list of unique bands in the data.
+
+        Returns
+        -------
+        result : numpy array
+            An array of the unique bands.
+        """
+        return np.unique(self.bands)
 
     def find_max_flux(self, error_coeff=-1.0, band=None):
         """Find the value and timestamp of the maximum flux in
@@ -105,20 +150,54 @@ class Lightcurve:
             The padded lightcurve. Returns self if in_place == True.
         """
         sort_idx = np.argsort(self.times)
-        if in_place:
-            self.times = self.times[sort_idx]
-            self.fluxes = self.fluxes[sort_idx]
-            self.flux_errors = self.flux_errors[sort_idx]
-            self.bands = self.bands[sort_idx]
-            return self
-        else:
-            return Lightcurve(
-                self.times[sort_idx],
-                self.fluxes[sort_idx],
-                self.flux_errors[sort_idx],
-                self.bands[sort_idx],
-                name=self.name,
-            )
+        return self._reindex(sort_idx, in_place=in_place)
+
+    def filter_by_band(self, keep_bands, in_place=True):
+        """Filter the light curve to keep only the specified bands.
+
+        Parameters
+        ----------
+        keep_bands : array-like
+            An array of bands to include in the final data.
+        in_place : bool
+            A Boolean indicating whether to modify the data in-place.
+
+        Returns
+        -------
+        result : Lightcurve
+            The padded lightcurve. Returns self if in_place == True.
+        """
+        keep_row = np.isin(self.bands, keep_bands)
+        return self._reindex(keep_row, in_place=in_place)
+
+    def band_as_int(self, ordered_bands, fail_on_missing=True):
+        """Returns the band array as integers corresponding to the band's position in
+        ordered_bands.
+
+        Parameters
+        ----------
+        ordered_bands : array_like
+            The order in which to enumerate the bands.
+        fail_on_missing : bool
+            Raise an exception if one of the bands is not included in the ordering.
+
+        Returns
+        -------
+        result : array_like
+            The list of bands as integers. Uses -1 for unspecified bands.
+
+        Raises
+        ------
+        ValueError is a band in the light curve is not included in ordered_bands
+        and fail_on_missing is True.
+        """
+        if not np.all(np.isin(self.bands, ordered_bands)) and fail_on_missing:
+            raise ValueError("ERROR: Unmapped bands found in band_as_int.")
+
+        result = np.array([-1] * len(self.bands))
+        for idx, band in enumerate(ordered_bands):
+            result[self.bands == band] = idx
+        return result
 
     def pad_bands(self, bands, size, in_place=True):
         """Truncate or pad the bands so that each band has
@@ -237,16 +316,11 @@ class Lightcurve:
         fdata = arr[1][good_rows].astype(float)
         edata = arr[2][good_rows].astype(float)
         bdata = arr[3][good_rows]
+        lc = Lightcurve(tdata, fdata, edata, bdata, name=curve_name)
 
         # Enforce the time ceiling if there is one.
         if t0_lim is not None:
-            good_rows_time = tdata <= t0_lim
-            tdata = tdata[good_rows_time]
-            fdata = fdata[good_rows_time]
-            edata = edata[good_rows_time]
-            bdata = bdata[good_rows_time]
-
-        lc = Lightcurve(tdata, fdata, edata, bdata, name=curve_name)
+            lc = lc._reindex(tdata <= t0_lim)
 
         # Shift the time to align 0.0 with maximum flux.
         if lc.obs_count(band=ref_band) > 0 and shift_time:

--- a/src/superphot_plus/lightcurve.py
+++ b/src/superphot_plus/lightcurve.py
@@ -45,7 +45,7 @@ class Lightcurve:
         indices : array_like
             This can either be an array-like of integer indices to keep
             and the order in which to put them or an array-like of bools
-            that indicate whether to each each entry.
+            that indicate whether to keep each entry.
         in_place : bool
             A Boolean indicating whether to modify the data in-place or
             make a new copy of the light curve.

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -220,7 +220,7 @@ def test_band_as_int():
 
     # Only a subset of the bands included.
     res2 = lc.band_as_int(["r", "g"], fail_on_missing=False)
-    assert np.all(res1 == np.array([0, 0, 1, 0, 1, -1, 1, -1, 0]))
+    assert np.all(res2 == np.array([0, 0, 1, 0, 1, -1, 1, -1, 0]))
 
     # A subset of bands with strict checking.
     with pytest.raises(ValueError, match="ERROR: Unmapped bands found in band_as_int."):

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -20,6 +20,7 @@ def test_create():
     assert lc.name is None
 
     # Check the per-band counts
+    assert np.all(lc.unique_bands() == np.array(["g", "r"]))
     assert lc.obs_count() == 10
     assert lc.obs_count("r") == 9
     assert lc.obs_count("g") == 1
@@ -177,6 +178,55 @@ def test_sort_copy():
     assert np.all(lc.bands == bands)
 
 
+def test_filter_bands():
+    times = np.array(range(9))
+    fluxes = np.array(range(10, 19))
+    bands = np.array(["r", "r", "g", "r", "g", "b", "g", "i", "r"])
+    errors = np.array(range(9)) / 10.0
+    lc = Lightcurve(times, fluxes, errors, bands)
+    assert np.all(lc.unique_bands() == np.array(["b", "g", "i", "r"]))
+
+    lc2 = lc.filter_by_band(["r", "g"], in_place=False)
+
+    # New array is filtered.
+    assert np.all(lc2.times == np.array([0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0]))
+    assert np.all(lc2.fluxes == np.array([10.0, 11.0, 12.0, 13.0, 14.0, 16.0, 18.0]))
+    assert np.all(lc2.flux_errors == np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.6, 0.8]))
+    assert np.all(lc2.bands == np.array(["r", "r", "g", "r", "g", "g", "r"]))
+
+    # Original array is unchanged.
+    assert np.all(lc.times == times)
+    assert np.all(lc.fluxes == fluxes)
+    assert np.all(lc.flux_errors == errors)
+    assert np.all(lc.bands == bands)
+
+    # Do the filtering in place and check the original.
+    lc3 = lc.filter_by_band(["r", "g"], in_place=True)
+    assert np.all(lc.times == np.array([0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0]))
+    assert np.all(lc.fluxes == np.array([10.0, 11.0, 12.0, 13.0, 14.0, 16.0, 18.0]))
+    assert np.all(lc.flux_errors == np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.6, 0.8]))
+    assert np.all(lc.bands == np.array(["r", "r", "g", "r", "g", "g", "r"]))
+
+
+def test_band_as_int():
+    times = np.array(range(9))
+    fluxes = np.array(range(10, 19))
+    bands = np.array(["r", "r", "g", "r", "g", "b", "g", "i", "r"])
+    errors = np.array(range(9)) / 10.0
+    lc = Lightcurve(times, fluxes, errors, bands)
+
+    res1 = lc.band_as_int(["r", "g", "i", "b"])
+    assert np.all(res1 == np.array([0, 0, 1, 0, 1, 3, 1, 2, 0]))
+
+    # Only a subset of the bands included.
+    res2 = lc.band_as_int(["r", "g"], fail_on_missing=False)
+    assert np.all(res1 == np.array([0, 0, 1, 0, 1, -1, 1, -1, 0]))
+
+    # A subset of bands with strict checking.
+    with pytest.raises(ValueError, match="ERROR: Unmapped bands found in band_as_int."):
+        _ = lc.band_as_int(["r", "g"])
+
+
 def test_padding():
     # Add 7 points in r, 3 in g, 1 in b.
     times = np.array([0.0, 1.5, 5.0, 1.0, 6.0, 2.0, 3.0, 4.0, 0.5, 2.5, 0.05])
@@ -184,6 +234,7 @@ def test_padding():
     bands = np.array(["r", "g", "r", "r", "r", "r", "r", "r", "g", "g", "b"])
     errors = np.array([0.1] * 11)
     lc = Lightcurve(times, fluxes, errors, bands)
+    assert np.all(lc.unique_bands() == np.array(["b", "g", "r"]))
 
     # Do the padding
     lc2 = lc.pad_bands(["r", "g"], 6, in_place=False)
@@ -191,6 +242,7 @@ def test_padding():
     assert lc2.obs_count("r") == 6
     assert lc2.obs_count("g") == 6
     assert lc2.obs_count("b") == 0
+    assert np.all(lc2.unique_bands() == np.array(["g", "r"]))
 
     # Check that lc2 is correctly padded and ordered by band.
     exp_times = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 5000.0, 5000.0, 5000.0])

--- a/tests/superphot_plus/test_lightcurve.py
+++ b/tests/superphot_plus/test_lightcurve.py
@@ -7,7 +7,7 @@ from superphot_plus.lightcurve import Lightcurve
 
 
 def test_create():
-    times = np.array(range(10))
+    times = np.arange(10)
     fluxes = np.array([100.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1])
     bands = np.array(["r", "r", "r", "r", "r", "r", "r", "r", "r", "g"])
     errors = np.array([0.1] * 10)
@@ -27,13 +27,13 @@ def test_create():
     assert lc.obs_count("b") == 0
 
     # Fail a creation
-    times2 = np.array(range(20))
+    times2 = np.arange(20)
     with pytest.raises(ValueError):
         lc2 = Lightcurve(times2, fluxes, bands, errors)
 
 
 def test_max_flux():
-    times = np.array(range(11))
+    times = np.arange(11)
     fluxes = np.array([1.1, 0.2, 0.3, 0.1, 100.2, 20.3, 0.1, 0.1, 1.1, 0.1, 1000.0])
     bands = np.array(["r", "r", "r", "r", "g", "r", "r", "r", "g", "g", "b"])
     errors = np.array([0.1] * 11)
@@ -77,7 +77,7 @@ def test_write_and_read_single_lightcurve(tmp_path):
     # Create fake data. Note that the first point in the fluxes must be the brightest
     # and the first time stamp must be zero, because of how read_single_lightcurve
     # shifts the times to be zero at the peak.
-    times = np.array(range(10))
+    times = np.arange(10)
     fluxes = np.array([100.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1])
     bands = np.array(["r"] * 10)
     errors = np.array([0.1] * 10)
@@ -127,7 +127,7 @@ def test_write_and_read_single_lightcurve_no_shift(tmp_path):
 
 
 def test_write_and_read_single_lightcurve_nans(tmp_path):
-    times = np.array(range(8))
+    times = np.arange(8)
     fluxes = np.array([0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.0])
     bands = np.array(["g"] * 8)
     errors = np.array([0.1, 0.1, 0.1, 0.1, np.NAN, 0.1, np.NAN, 0.2])
@@ -179,10 +179,10 @@ def test_sort_copy():
 
 
 def test_filter_bands():
-    times = np.array(range(9))
+    times = np.arange(9)
     fluxes = np.array(range(10, 19))
     bands = np.array(["r", "r", "g", "r", "g", "b", "g", "i", "r"])
-    errors = np.array(range(9)) / 10.0
+    errors = np.arange(9) / 10.0
     lc = Lightcurve(times, fluxes, errors, bands)
     assert np.all(lc.unique_bands() == np.array(["b", "g", "i", "r"]))
 
@@ -209,10 +209,10 @@ def test_filter_bands():
 
 
 def test_band_as_int():
-    times = np.array(range(9))
+    times = np.arange(9)
     fluxes = np.array(range(10, 19))
     bands = np.array(["r", "r", "g", "r", "g", "b", "g", "i", "r"])
-    errors = np.array(range(9)) / 10.0
+    errors = np.arange(9) / 10.0
     lc = Lightcurve(times, fluxes, errors, bands)
 
     res1 = lc.band_as_int(["r", "g", "i", "b"])


### PR DESCRIPTION
This PR is part of the larger shift to making the code handle an arbitrary set of bands. This adds functionality for:
- Finding the bands in a `Lightcurve`
- Filtering the `Lightcurve` data by band
- Mapping the bands to integers (for use in numpyro MCMC).

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation